### PR TITLE
put quotes around %%workdir%% in line 159

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 #
 #  build.py
-#  
+#
 #  Copyright 2015 Ikey Doherty <ikey@solus-project.com>
-#  
+#
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
@@ -156,7 +156,7 @@ def escape(inp, wdir, name):
 set -e
 set -x
 export TERM=dumb
-cd %%workdir%%;
+cd "%%workdir%%";
 export CFLAGS="%%CFLAGS%%"
 export CXXFLAGS="%%CXXFLAGS%%"
 export LDFLAGS="%%LDFLAGS%%"


### PR DESCRIPTION
This is to accommodate work directories with spaces in the name. I encountered this issue earlier today.

Note: This fix is untested, because each time I run evobuild it redownloads ypkg in my chroot, overwriting edits I made. That said, putting quotes around an argument in 'cd' seems like something that at the very least won't break anything.