### PR TITLE
Amend libexecdir for meson

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -17,7 +17,7 @@ actions:
         -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%PREFIX%
     # Example: %meson_configure ..
     - meson_configure: |
-        CFLAGS="%CFLAGS%" CXXFLAGS="%CXXFLAGS%" LDFLAGS="%LDFLAGS%" meson --prefix %PREFIX% --buildtype=plain --libdir="lib%LIBSUFFIX%" --libexecdir="lib%LIBSUFFIX%%PKGNAME%"
+        CFLAGS="%CFLAGS%" CXXFLAGS="%CXXFLAGS%" LDFLAGS="%LDFLAGS%" meson --prefix %PREFIX% --buildtype=plain --libdir="lib%LIBSUFFIX%" --libexecdir="lib%LIBSUFFIX%/%PKGNAME%"
     - meson_build: |
         ninja %JOBS%
     - meson_install: |


### PR DESCRIPTION
So looking at the code changes this morning, you cut the / when you changed from %libdir%. This makes it --libexecdir=lib64valum from the build log and rebuilding it locally.