### PR TITLE
rc.yml: Add support for qmake packages

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -22,6 +22,8 @@ actions:
         ninja %JOBS%
     - meson_install: |
         DESTDIR="%installroot%" ninja install %JOBS%
+    - qmake: |
+        qmake QMAKE_CFLAGS_RELEASE="%CFLAGS%" QMAKE_CXXFLAGS_RELEASE="%CXXFLAGS%" QMAKE_LFLAGS="%LDFLAGS%"
     - patch: |
         patch -t -E --no-backup-if-mismatch -f
     # Only works if the user has a series file. They can provide the name to


### PR DESCRIPTION
So I noticed qmake doesn't honour Solus flags. It takes the qmake flags set when building qt5. By default this is just -O2. Also doesn't honour LDFLAGS and so on. My research led to these flags and a test build using this line on ricochet, was honouring the Solus flags. 

The directories are still determined by what is set by Qt5 at build and that is likely the right thing as that's where it will search for them. 