### PR TITLE
Added macros for Haskell Cabal

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -44,6 +44,29 @@ actions:
             done < $srs
         }
         apply_patches
+    # Make life easier with Haskell
+    - cabal_configure: |
+        export GHCV=`readlink /usr/bin/ghc | cut -d'-' -f2`
+        mkdir -p ~/.ghc/x86_64-linux-$GHCV/package.conf.d
+        cp /usr/lib64/ghc-$GHCV/package.conf.d/* ~/.ghc/x86_64-linux-$GHCV/package.conf.d
+        ghc-pkg recache --user
+        cabal configure --prefix=%PREFIX% \
+                        --libdir=%libdir% \
+                        --libexecdir=%libdir%/%PKGNAME% \
+                        --libsubdir="\$compiler/\$pkgid" \
+                        --sysconfdir=/etc \
+                        --enable-executable-dynamic \
+                        --enable-shared
+    - cabal_build: |
+        cabal build %JOBS%
+    - cabal_install: |
+        cabal copy --destdir=$installdir
+    - cabal_register: |
+        export GHC=`readlink /usr/bin/ghc`
+        export LIBNAME=`echo $package | cut -d'-' -f2-`
+        cabal register --gen-pkg-config
+        install -D -m 00644 $LIBNAME-$version.conf $installdir%libdir%/$GHC/package.conf.d/$LIBNAME-$version.conf
+        rm $installdir%libdir%/$GHC/$LIBNAME-$version/*.a
     # Make life easier with Perl
     - perl_setup: |
         function perl_setup() {


### PR DESCRIPTION
These macros should make it considerably faster/easier to package haskell libraries and development binaries:
* `cabal_configure`
  Create a user package database, rebuild the package.cache for ghc, then configure for a dynamically linked build
* `cabal_build`
  Compile the source with %JOBS% processes
* `cabal_install`
  Install the outputs to $installdir
* `cabal_register`
  Generate the package.conf.d entry, install it, then wipe out any static libs.

Caveats:
1. Must always install `ghc` and `haskell-cabal-install` for the macros to work.
2. `cabal_register` always removes static libs
3. `cabal_register` assumes library is prefixed with `haskell-`