### PR TITLE
Added Macros and Pattern for easy Haskell packaging

### DIFF
--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -205,6 +205,9 @@ class PackageGenerator:
         self.add_pattern("/usr/lib/cmake/", "devel")
         self.add_pattern("/usr/lib32/cmake/", "32bit-devel")
 
+        # Haskell
+        self.add_pattern("/usr/lib64/ghc-*/*/*.a", "devel")
+
         # Vala..
         self.add_pattern("/usr/share/vala*/vapi/*", "devel")
         self.add_pattern("/usr/share/vala*/vapi/*", "devel")

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -44,6 +44,26 @@ actions:
             done < $srs
         }
         apply_patches
+    # Make life easier with Haskell
+    - cabal_configure: |
+    export GHCV=$(ghc --numeric-version)
+        mkdir -p ~/.ghc/%ARCH%-linux-$GHCV/package.conf.d
+        cp /usr/lib%LIBSUFFIX%/ghc-$GHCV/package.conf.d/* ~/.ghc/%ARCH%-linux-$GHCV/package.conf.d
+        ghc-pkg recache --user
+        cabal configure --prefix=%PREFIX% \
+                        --libdir=%libdir% \
+                        --libsubdir="\$compiler/\$pkgid" \
+                        --sysconfdir=/etc \
+                        --enable-executable-dynamic \
+                        --enable-shared
+    - cabal_build: |
+        cabal build %JOBS%
+    - cabal_install: |
+        cabal copy --destdir=$installdir
+    - cabal_register: |
+        export GHCV=$(ghc --numeric-version)
+        cabal register --gen-pkg-config=$package-$version.conf
+        install -D -m 00644 $package-$version.conf $installdir%libdir%/ghc-$GHCV/package.conf.d/$package-$version.conf
     # Make life easier with Perl
     - perl_setup: |
         function perl_setup() {


### PR DESCRIPTION
These macros should make it considerably faster/easier to package Haskell libraries and development binaries:
* `cabal_configure`
  Create a user package database, rebuild the 'package.cache' for `ghc`, then configure for a dynamically linked build
* `cabal_build`
  Compile the source with %JOBS% processes
* `cabal_install`
  Install the outputs to $installdir
* `cabal_register`
  Generate the package.conf.d entry and install it

A pattern was also added to move the static libs into a -devel sub-package

**Caveat**
You must always install `ghc` and `haskell-cabal-install` for the macros to work.