### PR TITLE
Added ARCH macro to expose architecture to package.yml

### DIFF
--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -131,6 +131,7 @@ class ScriptGenerator:
         self.define_macro("LDFLAGS", " ".join(self.context.build.ldflags))
 
         self.define_macro("HOST", self.context.build.host)
+        self.define_macro("ARCH", self.context.build.arch)
         self.define_macro("PKGNAME", self.spec.pkg_name)
         self.define_macro("PKGFILES", self.context.files_dir)
 


### PR DESCRIPTION
This fixes the Haskell macros. Apologies for not mentioning it in that PR.