### PR TITLE
context: Enable atomic updates for PGO generation

### DIFF
--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -32,7 +32,8 @@ BIND_NOW_FLAGS = ["-Wl,-z,now", "-Wl,-z -Wl,relro", "-Wl,-z -Wl,now"]
 SIZE_FLAGS = "-Os -ffunction-sections"
 
 # GCC PGO flags
-PGO_GEN_FLAGS = "-fprofile-generate -fprofile-dir=\"{}\""
+PGO_GEN_FLAGS = "-fprofile-generate -fprofile-dir=\"{}\" " \
+                "-fprofile-update=atomic"
 PGO_USE_FLAGS = "-fprofile-use -fprofile-dir=\"{}\" -fprofile-correction"
 
 # Clang can handle parameters to the args unlike GCC


### PR DESCRIPTION
New flag in GCC 7 -fprofile-update=atomic prevents creation of corrupted
profiles created during instrumentation, but with a speed penalty.

I don't see how this can be a bad thing! (I have tested it, and it does make it a little slower, but not a real concern)