### PR TITLE
packages: Add pattern to move KDE dev docs to devel

### DIFF
--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -210,7 +210,12 @@ class PackageGenerator:
 
         # Vala..
         self.add_pattern("/usr/share/vala*/vapi/*", "devel")
-        self.add_pattern("/usr/share/vala*/vapi/*", "devel")
+
+        # KDE developer documentation
+        self.add_pattern("/usr/share/doc/qt5/*.qch", "devel",
+                         priority=PRIORITY_DEFAULT+1)
+        self.add_pattern("/usr/share/doc/qt5/*.tags", "devel",
+                         priority=PRIORITY_DEFAULT+1)
 
     def add_file(self, path):
         """ Add a file path to the owned list and place it into the correct


### PR DESCRIPTION
QCH files are used with qt-creator and kdevelop, which are helpful only for
people developing on Solus. If they are building using a lib, they will need
the -devel package installed so they will also get these files. Want to move
them out of "main" as they can be significantly larger than the smaller
libraries themselves. Specific and higher priority to override the
/usr/share/doc rule already included.

Also removed duplicate vala pattern.

Signed-off-by: Peter O'Connor <peter@solus-project.com>