### PR TITLE
rc: Add lrelease override for qmake4 macro

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -24,7 +24,7 @@ actions:
     - qmake: |
         qmake QMAKE_CFLAGS_RELEASE="%CFLAGS%" QMAKE_CXXFLAGS_RELEASE="%CXXFLAGS%" QMAKE_LFLAGS="%LDFLAGS%"
     - qmake4: |
-        qmake-qt4 QMAKE_CFLAGS_RELEASE="%CFLAGS%" QMAKE_CXXFLAGS_RELEASE="%CXXFLAGS%" QMAKE_LFLAGS="%LDFLAGS%" QMAKE_MOC=/usr/bin/moc-qt4 QMAKE_RCC=/usr/bin/rcc-qt4 QMAKE_UIC=/usr/bin/uic-qt4
+        qmake-qt4 QMAKE_CFLAGS_RELEASE="%CFLAGS%" QMAKE_CXXFLAGS_RELEASE="%CXXFLAGS%" QMAKE_LFLAGS="%LDFLAGS%" QMAKE_LRELEASE=/usr/bin/lrelease-qt4 QMAKE_MOC=/usr/bin/moc-qt4 QMAKE_RCC=/usr/bin/rcc-qt4 QMAKE_UIC=/usr/bin/uic-qt4
     - patch: |
         patch -t -E --no-backup-if-mismatch -f
     # Only works if the user has a series file. They can provide the name to


### PR DESCRIPTION
Came across this when fixing x2goclient. It's not commonly used, but will fix
building on some packages.

Signed-off-by: Peter O'Connor <peter@solus-project.com>