### PR TITLE
ypkg2: Extend optimize to a list and add lto optimization

### DIFF
--- a/ypkg2/ypkgspec.py
+++ b/ypkg2/ypkgspec.py
@@ -210,7 +210,7 @@ class YpkgSpec:
             ("component", MultimapFormat(self, self.add_component, "main")),
             ("conflicts", MultimapFormat(self, self.add_conflict, "main")),
             ("replaces", MultimapFormat(self, self.add_replace, "main")),
-            ("optimize", unicode),
+            ("optimize", OneOrMoreString),
         ])
         # Build steps are handled separately
         self.build_steps = OrderedDict([


### PR DESCRIPTION
Enable multiple optimizations to be listed and enable an easy lto and to unroll
loops (if ever needed) option for packages where it improves size/performance.

Perhaps not the most elegant python, but I know enough now to make any necessary changes to clang flags/ld to try and get it working better.

Has been tested in various multiple flag combinations on zlib.