### PR TITLE
rc: Add support for easy rubygems

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -107,6 +107,24 @@ actions:
         python3 setup.py build -b __py3_build
     - python3_install: |
         python3 setup.py build -b __py3_build install --root="%installroot%"
+    # Make life easier with Ruby gems
+    - gem_build: |
+        gem build *.gemspec
+    - gem_install: |
+        function gem_install() {
+            export geminstalldir=$(ruby -e'puts Gem.default_dir')
+            export GEM_HOME=$geminstalldir
+            export GEM_PATH=$geminstalldir
+            if [ -a *.gem ]; then
+                gem install --minimal-deps --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" *.gem $* || exit 1
+            else
+                gem install --minimal-deps --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" $sources/*.gem $* || exit 1
+            fi
+            if [[ -e "$installdir/$geminstalldir/cache" ]]; then
+                rm -rfv $installdir/$geminstalldir/cache
+            fi
+        }
+        gem_install
     - waf_configure: |
         ./waf configure --prefix=%PREFIX%
     - waf_build: |


### PR DESCRIPTION
More ruby is starting to enter Solus, and currently they are all bundling their
own gems. This means if two packages use the same gem they conflict. This makes
it easy to package Rubygems so with start doing that instead (and it becomes
like perl/python with lots of little deps). It should also allow for networking
to be turned off for these packages. See T5014

It uses * to find the files as it will differ from the package name in many
cases (particularly where you need to add ruby-, but you can't remove it as
that breaks packages who's name uses ruby-). There should only be one per
package, but may be in different locations.

It may need some tweaks but will allow someone to start fixing up our ruby!

Signed-off-by: Peter O'Connor <peter@solus-project.com>