### PR TITLE
packages: Put straggling .pc files in devel package

### DIFF
--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -181,6 +181,7 @@ class PackageGenerator:
         self.add_pattern("/usr/lib/lib*.a", "devel")
         self.add_pattern("/usr/lib/pkgconfig/*.pc", "devel")
         self.add_pattern("/usr/lib64/pkgconfig/*.pc", "devel")
+        self.add_pattern("/usr/share/pkgconfig/*.pc", "devel")
         self.add_pattern("/usr/include/", "devel")
         self.add_pattern("/usr/share/man3/", "devel",
                          priority=PRIORITY_DEFAULT+1)


### PR DESCRIPTION
Some sources utilise .pc files in /usr/share/pkgconfig/*.pc

This ensures that they are not included in the main package.

Signed-off-by: Peter O'Connor <peter@solus-project.com>