### PR TITLE
rc: Fix ruby gem macros

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -173,16 +173,23 @@ actions:
         python3_install
     # Make life easier with Ruby gems
     - gem_build: |
-        gem build *.gemspec
+        function gem_build() {
+            if [ -z "$1" ]; then
+                gem build *.gemspec || exit 1
+            else
+                gem build $* || exit 1
+            fi
+        }
+        gem_build
     - gem_install: |
         function gem_install() {
             export geminstalldir=$(ruby -e'puts Gem.default_dir')
             export GEM_HOME=$geminstalldir
             export GEM_PATH=$geminstalldir
             if [ -a *.gem ]; then
-                gem install --minimal-deps --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" *.gem $* || exit 1
+                gem install --ignore-dependencies --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" *.gem || exit 1
             else
-                gem install --minimal-deps --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" $sources/*.gem $* || exit 1
+                gem install --ignore-dependencies --no-user-install --no-document -i "$installdir/$geminstalldir" -n "$installdir/usr/bin" $sources/*.gem || exit 1
             fi
             if [[ -e "$installdir/$geminstalldir/cache" ]]; then
                 rm -rfv $installdir/$geminstalldir/cache


### PR DESCRIPTION
Lessons learnt from packaging up a bunch of ruby gems to do so without turning
on networking.

 - Add ability to specifiy .gemspec file (some have gemspecs for development
   versions)
 - Disable minimal dependency checking as it doesn't work as one would expect

Have been tested to build vagrant and the 35 gem deps all without networking.

Signed-off-by: Peter O'Connor <peter@solus-project.com>