### PR TITLE
Update avx2 build for glibc-2.26 changes

### DIFF
--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -297,7 +297,7 @@ In the majority of cases, this is the desired behaviour in full build environmen
 If set, the package will be rebuilt again specifically to enable libraries to be optimised to use \fBAdvanced Vector Extensions\fR\.
 .
 .IP
-The build will be configured with a library directory suffix of \fBavx2\fR, i\.e\. \fB/usr/lib64/avx2\fR or \fB/usr/lib32/avx2\fR\. These libraries will be automatically loaded on the Solus installation if the hardware support is present\.
+The build will be configured with a library directory suffix of \fBhaswell\fR, i\.e\. \fB/usr/lib64/haswell\fR or \fB/usr/lib32/haswell\fR\. These libraries will be automatically loaded on the Solus installation if the hardware support is present\.
 .
 .IP "\(bu" 4
 \fBoptimize\fR [list]

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -356,8 +356,8 @@ additional functionality.</p>
 <p>  If set, the package will be rebuilt again specifically to enable libraries
   to be optimised to use <strong>Advanced Vector Extensions</strong>.</p>
 
-<p>  The build will be configured with a library directory suffix of <code>avx2</code>,
-  i.e. <code>/usr/lib64/avx2</code> or <code>/usr/lib32/avx2</code>. These libraries will be
+<p>  The build will be configured with a library directory suffix of <code>haswell</code>,
+  i.e. <code>/usr/lib64/haswell</code> or <code>/usr/lib32/haswell</code>. These libraries will be
   automatically loaded on the Solus installation if the hardware support
   is present.</p></li>
 <li><p><code>optimize</code> [list]</p>

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -298,8 +298,8 @@ additional functionality.
     If set, the package will be rebuilt again specifically to enable libraries
     to be optimised to use **Advanced Vector Extensions**.
 
-    The build will be configured with a library directory suffix of `avx2`,
-    i.e. `/usr/lib64/avx2` or `/usr/lib32/avx2`. These libraries will be
+    The build will be configured with a library directory suffix of `haswell`,
+    i.e. `/usr/lib64/haswell` or `/usr/lib32/haswell`. These libraries will be
     automatically loaded on the Solus installation if the hardware support
     is present.
 

--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -405,8 +405,8 @@ class PackageExaminer:
         if pretty.startswith("/emul32"):
             return True
         # Nuke AVX2 dir .a files with no remorse
-        if (pretty.startswith("/usr/lib64/avx2/") or
-                pretty.startswith("/usr/lib32/avx2/")):
+        if (pretty.startswith("/usr/lib64/haswell/") or
+                pretty.startswith("/usr/lib32/haswell/")):
             if ".so" not in pretty:
                 return True
             # Don't want .so links, they're useless.

--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -106,7 +106,7 @@ class ScriptGenerator:
 
         if self.context.emul32:
             if self.context.avx2:
-                self.define_macro("libdir", "/usr/lib32/avx2")
+                self.define_macro("libdir", "/usr/lib32/haswell")
             else:
                 self.define_macro("libdir", "/usr/lib32")
             self.define_macro("LIBSUFFIX", "32")
@@ -114,7 +114,7 @@ class ScriptGenerator:
         else:
             # 64-bit AVX2 build in subdirectory
             if self.context.avx2:
-                self.define_macro("libdir", "/usr/lib64/avx2")
+                self.define_macro("libdir", "/usr/lib64/haswell")
             else:
                 self.define_macro("libdir", "/usr/lib64")
             self.define_macro("LIBSUFFIX", "64")

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -57,7 +57,8 @@ PGO_USE_FLAGS_CLANG = "-fprofile-instr-use=\"{}/default.profdata\" " \
                       "-fprofile-correction"
 
 # AVX2
-AVX2_FLAGS = "-mavx2"
+AVX2_ARCH = "haswell"
+AVX2_TUNE = "haswell"
 
 
 class Flags:
@@ -269,6 +270,17 @@ class YpkgContext:
                                 self.spec.pkg_name,
                                 pgoSuffix))
 
+    def repl_flags_avx2(self, flags):
+        """ Adjust flags to compensate for avx2 build """
+        ncflags = list()
+        for flag in flags:
+            if flag.startswith("-march="):
+                flag = "-march={}".format(AVX2_ARCH)
+            elif flag.startswith("-mtune="):
+                flag = "-mtune={}".format(AVX2_TUNE)
+            ncflags.append(flag)
+        return ncflags
+
     def init_config(self):
         """ Initialise our configuration prior to building """
         conf = pisi.config.Config()
@@ -371,8 +383,8 @@ class YpkgContext:
 
     def init_avx2(self):
         """ Adjust flags for AVX2 builds """
-        self.build.cflags.extend(AVX2_FLAGS.split(" "))
-        self.build.cxxflags.extend(AVX2_FLAGS.split(" "))
+        self.build.cflags = self.repl_flags_avx2(self.build.cflags)
+        self.build.cxxflags = self.repl_flags_avx2(self.build.cxxflags)
 
     def enable_pgo_generate(self):
         """ Enable GPO generate step """


### PR DESCRIPTION
The introduction of glibc-2.26 results in a change in directory for avx2
libraries. Glibc now uses the `haswell` directory, while the optimizations are
increased to `-march=haswell` to enable other math instructions that will
be present when the avx2 libraries are used.

Signed-off-by: Peter O'Connor <peter@solus-project.com>