### PR TITLE
Fix LTO builds after changes to the optimize key

### DIFF
--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -269,11 +269,13 @@ def strip_file(context, pretty, file, magic_string, mode=None):
     if not context.spec.pkg_strip:
         return
     exports = ["LC_ALL=C"]
-    if context.spec.pkg_optimize == "speed":
-        exports.extend([
-            "AR=\"gcc-ar\"",
-            "RANLIB=\"gcc-ranlib\"",
-            "NM=\"gcc-nm\""])
+    if context.spec.pkg_optimize and not context.spec.pkg_clang:
+        if "thin-lto" in context.spec.pkg_optimize \
+                or "lto" in context.spec.pkg_optimize:
+            exports.extend([
+                "AR=\"gcc-ar\"",
+                "RANLIB=\"gcc-ranlib\"",
+                "NM=\"gcc-nm\""])
 
     cmd = "{} strip {} \"{}\""
     flags = ""

--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -170,10 +170,12 @@ class ScriptGenerator:
             self.define_export("LD_AS_NEEDED", "1")
 
         # Handle lto correctly
-        if self.context.spec.pkg_optimize == "speed":
-            self.define_export("AR", "gcc-ar")
-            self.define_export("RANLIB", "gcc-ranlib")
-            self.define_export("NM", "gcc-nm")
+        if self.context.spec.pkg_optimize and not self.context.spec.pkg_clang:
+            if "thin-lto" in self.context.spec.pkg_optimize \
+                    or "lto" in self.context.spec.pkg_optimize:
+                self.define_export("AR", "gcc-ar")
+                self.define_export("RANLIB", "gcc-ranlib")
+                self.define_export("NM", "gcc-nm")
 
         if not console_ui.allow_colors:
             self.define_export("TERM", "dumb")

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -40,8 +40,11 @@ SIZE_FLAGS_CLANG = "-O2"
 # Allow optimizing for lto
 LTO_FLAGS = "-flto"
 
+# Use linker plugin when not compiling with Clang
+LTO_FLAGS_GCC = "-fuse-linker-plugin"
+
 # Use gold for thin LTO
-THIN_LTO_FLAGS = "-flto=thin"
+THIN_LTO_FLAGS = "-flto=thin -fuse-ld=gold"
 
 # Allow unrolling loops
 UNROLL_LOOPS_FLAGS = "-funroll-loops"
@@ -107,6 +110,8 @@ class Flags:
                     newflags.extend(SIZE_FLAGS.split(" "))
         elif opt_type == "lto":
             newflags.extend(LTO_FLAGS.split(" "))
+            if not clang:
+                newflags.extend(LTO_FLAGS_GCC.split(" "))
         elif opt_type == "unroll-loops":
             newflags.extend(UNROLL_LOOPS_FLAGS.split(" "))
         elif opt_type == "no-bind-now":
@@ -115,6 +120,8 @@ class Flags:
             newflags = Flags.filter_flags(f, SYMBOLIC_FLAGS)
         elif opt_type == "thin-lto":
             newflags.extend(THIN_LTO_FLAGS.split(" "))
+            if not clang:
+                newflags.extend(LTO_FLAGS_GCC.split(" "))
         else:
             console_ui.emit_warning("Flags", "Unknown optimization: {}".
                                     format(opt_type))


### PR DESCRIPTION
Now uses gcc-{ar,ranlib,nm} which retains GIMPLE information. Updates support
for LTO with Clang and Gold linker to ensure the right flags are used.

Signed-off-by: Peter O'Connor <peter@solus-project.com>