### PR TITLE
rc: Add options to precompile python and qml files

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -41,6 +41,14 @@ actions:
         qmake QMAKE_CFLAGS_RELEASE="${CFLAGS}" QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}"
     - qmake4: |
         qmake-qt4 QMAKE_CFLAGS_RELEASE="${CFLAGS}" QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}" QMAKE_LRELEASE=/usr/bin/lrelease-qt4 QMAKE_MOC=/usr/bin/moc-qt4 QMAKE_RCC=/usr/bin/rcc-qt4 QMAKE_UIC=/usr/bin/uic-qt4
+    - qml_cache: |
+        pushd $installdir
+        for i in `find -type f -name "*.qml"`; do
+            if ! [ -a "${i}"c ]; then
+                qmlcachegen --target-architecture=x86_64 --target-abi=x86_64-little_endian-lp64 -o "${i}"c "${i}"
+            fi
+        done
+        popd
     - patch: |
         patch -t -E --no-backup-if-mismatch -f
     # Only works if the user has a series file. They can provide the name to
@@ -150,6 +158,15 @@ actions:
             popd
         }
         python_install
+    - python_compile: |
+        function python_compile() {
+            if [ -z "$1" ]; then
+                python2 -m compileall -q $installdir || exit 1
+            else
+                python2 -m compileall -q $* || exit 1
+            fi
+        }
+        python_compile
     - python3_setup: |
         function python3_setup() {
             if [[ -e $PKG_BUILD_DIR/.workdir ]]; then
@@ -185,6 +202,15 @@ actions:
             popd
         }
         python3_install
+    - python3_compile: |
+        function python3_compile() {
+            if [ -z "$1" ]; then
+                python3 -m compileall -q $installdir || exit 1
+            else
+                python3 -m compileall -q $* || exit 1
+            fi
+        }
+        python3_compile
     # Make life easier with Ruby gems
     - gem_build: |
         function gem_build() {


### PR DESCRIPTION
While most python builds currently include .pyc files, packages which aren't
primarily python don't include pre-compiled files for faster load and
performance. Macros are included for python2 and python3 that by default
compile all .py files in the installdir (which can be overridden).

The qml_cache macro is taken from extra-cmake-modules which is already in
heavy use, but unbundles the macro from the package.

Signed-off-by: Peter O'Connor <peter@solus-project.com>