### PR TITLE
Set GHC options in cabal_configure

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -80,7 +80,8 @@ actions:
                         --libsubdir="\$compiler/\$pkgid" \
                         --sysconfdir=/etc \
                         --enable-executable-dynamic \
-                        --enable-shared
+                        --enable-shared \
+                        --ghc-options="-O2 -fPIC"
     - cabal_build: |
         cabal build %JOBS%
     - cabal_install: |


### PR DESCRIPTION
Currently, GHC isn't doing code optimizations (default is -O0) or generating code with -FPIC. This fixes that by having Cabal set it at configure time.