### PR TITLE
Add CMAKE_INSTALL_LIBDIR to cmake macros

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -14,14 +14,16 @@ actions:
     - cmake: |
         cmake -DCMAKE_CFLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
         -DCMAKE_LD_FLAGS="${LDFLAGS}" -DCMAKE_LIB_SUFFIX="%LIBSUFFIX%" \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%PREFIX%
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%PREFIX% \
+        -DCMAKE_INSTALL_LIBDIR=lib%LIBSUFFIX%
     - cmake_ninja: |
         function cmake_ninja() {
             mkdir solusBuildDir && pushd solusBuildDir
             cmake -G Ninja .. \
             -DCMAKE_CFLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
             -DCMAKE_LD_FLAGS="${LDFLAGS}" -DCMAKE_LIB_SUFFIX="%LIBSUFFIX%" \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%PREFIX% $* || exit 1
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=%PREFIX% \
+            -DCMAKE_INSTALL_LIBDIR=lib%LIBSUFFIX% $* || exit 1
             popd
         }
         cmake_ninja


### PR DESCRIPTION
Because it's getting more and more common and in some packages we currently use `-DCMAKE_INSTALL_LIBDIR=%libdir%` instead of `-DCMAKE_INSTALL_LIBDIR=lib%LIBSUFFIX%` and this may cause problems like wrong pkgconfig.

Signed-off-by: Pierre-Yves <pyu@riseup.net>