### PR TITLE
Clang does not support the -fprofile-correction PGO flag

### DIFF
--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -55,8 +55,7 @@ PGO_USE_FLAGS = "-fprofile-use -fprofile-dir=\"{}\" -fprofile-correction"
 
 # Clang can handle parameters to the args unlike GCC
 PGO_GEN_FLAGS_CLANG = "-fprofile-instr-generate=\"{}/default-%m.profraw\""
-PGO_USE_FLAGS_CLANG = "-fprofile-instr-use=\"{}/default.profdata\" " \
-                      "-fprofile-correction"
+PGO_USE_FLAGS_CLANG = "-fprofile-instr-use=\"{}/default.profdata\""
 
 # AVX2
 AVX2_ARCH = "haswell"


### PR DESCRIPTION
See here https://github.com/llvm-mirror/clang/blob/master/test/Driver/clang_f_opts.c#L375

Is the case as of llvm 6 and before. It would be my belief that clang does this automatically. `zstd` is a package that contains a real world example of this warning.