### PR TITLE
Use same %libdir% directory for avx2 builds, then move libs

### DIFF
--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -119,6 +119,7 @@ def execute_step(context, step, step_n, work_dir):
     if context.avx2:
         script.define_export("AVX2BUILD", "1")
     extraScript = None
+    endScript = None
 
     # Allow GCC and such to pick up on our timestamp
     script.define_export("SOURCE_DATA_EPOCH",
@@ -137,6 +138,9 @@ def execute_step(context, step, step_n, work_dir):
         script.define_export("LLVM_PROFILE_FILE", profileFile)
         script.define_export("YPKG_PGO_DIR", context.get_pgo_dir())
 
+    if context.avx2 and step_n == "install":
+        endScript = "%avx2_lib_shift"
+
     exports = script.emit_exports()
 
     # Run via bash with enable and error
@@ -150,6 +154,8 @@ def execute_step(context, step, step_n, work_dir):
     if extraScript:
         full_text += "\n\n{}\n".format(extraScript)
     full_text += "\n\n{}\n".format(step)
+    if endScript:
+        full_text += "\n\n{}\n".format(endScript)
     output = script.escape_string(full_text)
 
     with tempfile.NamedTemporaryFile(prefix="ypkg-%s" % step_n) as script_ex:

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -256,6 +256,10 @@ actions:
         else
             echo "\n\nError: Profiling requested by ypkg but doesn't exist\n\n"
         fi
+    - avx2_lib_shift: |
+        install -dm00755 $PKG_BUILD_DIR/haswell
+        mv %installroot%/%libdir%/* $PKG_BUILD_DIR/haswell
+        mv $PKG_BUILD_DIR/haswell %installroot%/%libdir%/
 defines:
     - CONFOPTS: |
         --prefix=%PREFIX% --build=%HOST% --libdir=%libdir% --mandir=/usr/share/man \

--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -105,20 +105,13 @@ class ScriptGenerator:
     def init_default_macros(self):
 
         if self.context.emul32:
-            if self.context.avx2:
-                self.define_macro("libdir", "/usr/lib32/haswell")
-            else:
-                self.define_macro("libdir", "/usr/lib32")
+            self.define_macro("libdir", "/usr/lib32")
             self.define_macro("LIBSUFFIX", "32")
-            self.define_macro("PREFIX", "/usr")
         else:
-            # 64-bit AVX2 build in subdirectory
-            if self.context.avx2:
-                self.define_macro("libdir", "/usr/lib64/haswell")
-            else:
-                self.define_macro("libdir", "/usr/lib64")
+            self.define_macro("libdir", "/usr/lib64")
             self.define_macro("LIBSUFFIX", "64")
-            self.define_macro("PREFIX", "/usr")
+
+        self.define_macro("PREFIX", "/usr")
 
         self.define_macro("installroot", self.context.get_install_dir())
         self.define_macro("workdir", self.work_dir)


### PR DESCRIPTION
By default the lookup of libraries first searches for haswell libs. However,
when we build the libs with %libdir% /usr/lib64/haswell directory, it will
hardcode the library path for non LD_LIBRARY lookups in the library itself.
For example, glibc breaks when shipping select haswell libraries (there's no
need to duplicate most of them), as /usr/lib64/haswell/locale/locale-archive
becomes hardcoded path which does not exist.

Same applies to %libdir%/gconv/gconv-modules.

This patch ensures that libraries are built without haswell paths relying only
on LD_LIBRARY lookups to select the faster avx2 library versions where they
exist.

The sole drawback would be packages making full path symlinks would be broken.
This should be very rare (libnss and pulseaudio only on my system) which are
from symlinks we create in the build, so easily fixable.

Signed-off-by: Peter O'Connor <peter@solus-project.com>